### PR TITLE
Schedule hovering functionality

### DIFF
--- a/src/__tests__/DayShow.test.js
+++ b/src/__tests__/DayShow.test.js
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
-import DayShow from "../components/WeeklyShow.js";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DayShow from "../components/DayShow.js";
 import { sampleShow } from "../lib/test-utils.js";
-
-const color = "#F50046";
+import { colors } from "../lib/component-utils.js";
 
 describe("DayShow tests", () => {
 
@@ -12,10 +11,26 @@ describe("DayShow tests", () => {
     expect(screen.queryByText("Kyle Hooker")).toBeInTheDocument();
   });
 
-
   test("Show is correct color", () => {
     const { container } = render(<DayShow show={sampleShow}/>);
-    expect(container.firstChild).toHaveStyle(`background-color: ${color}`);
+    expect(container.firstChild).toHaveStyle(`background-color: ${colors[sampleShow.genres[0]]}`);
+  });
+
+  test("description appears on mouse enter", () => {
+    render(<DayShow show={sampleShow}/>);
+    const show = screen.getByText(sampleShow.title);
+    expect(show).toBeInTheDocument();
+    fireEvent.mouseEnter(show);
+    expect(screen.getByText(sampleShow.description)).toBeInTheDocument();
+    expect(screen.queryByText(sampleShow.title)).not.toBeInTheDocument();
+  });
+
+  test("description disappears on mouse leave", () => {
+    render(<DayShow show={sampleShow}/>);
+    fireEvent.mouseEnter(screen.getByText(sampleShow.title));
+    fireEvent.mouseLeave(screen.getByText(sampleShow.description));
+    expect(screen.queryByText(sampleShow.description)).not.toBeInTheDocument();
+    expect(screen.getByText(sampleShow.title)).toBeInTheDocument();
   });
 
 });

--- a/src/components/DaySchedule.js
+++ b/src/components/DaySchedule.js
@@ -9,7 +9,7 @@ export default function DaySchedule({ shows , day}){
   const showListSorted = showList.sort((a, b)=> {return a.time.hour - b.time.hour});
 
   const showsDisplayed = showListSorted.map((show) => {
-      return <li className={styles.showList} key={show.id} data-testid="day  show">
+      return <li className={styles.showList} key={show.id}>
         <DayShow show={show}/>
       </li>
     });

--- a/src/components/DayShow.js
+++ b/src/components/DayShow.js
@@ -7,8 +7,9 @@ import { useState } from "react";
 
 export default function DayShow({ show }){
   const [displayDescription, setDisplayDescription] = useState(false);
+
   const time = getTimeString(show.time.hour, show.time.duration);
-  const genrecolor = colors[show.genres[0].toLowerCase()]
+  const genrecolor = colors[show.genres[0].toLowerCase()];
 
   return (
    <div onMouseLeave={() => setDisplayDescription(false)} onMouseEnter={() => setDisplayDescription(true)}>
@@ -21,7 +22,7 @@ export default function DayShow({ show }){
           <p className={styles.ShowTitle}>{show.title}</p>
           <div className={styles.djs}>{show.DJs.join(", ")}</div>
         </div>}
-  </div>
+    </div>
   );
 }
 

--- a/src/components/DayShow.js
+++ b/src/components/DayShow.js
@@ -3,17 +3,32 @@ import styles from "../styles/DayShow.module.css";
 import { showType } from "../lib/types.js";
 import { getTimeString } from "../lib/component-utils.js";
 import { colors } from "../lib/component-utils.js";
+import { useState } from "react";
 
 export default function DayShow({ show }){
+  const [displayDescription, setDisplayDescription] = useState(false);
   const time = getTimeString(show.time.hour, show.time.duration);
   const genrecolor = colors[show.genres[0].toLowerCase()]
 
   return (
-    <div className={styles.DayShow} style={{"backgroundColor": genrecolor}}>
+   <div>
+
+
+    {
+      displayDescription 
+      ? <div className={styles.description} onMouseLeave={() => setDisplayDescription(false)} onMouseEnter={() => setDisplayDescription(true)}>
+        {show.description}
+        </div> 
+      :
+
+    <div className={styles.details} onMouseEnter={() => setDisplayDescription(true)} onMouseLeave={() => setDisplayDescription(false)} 
+     style={{"backgroundColor": genrecolor}}>
       <div className={styles.time}>{time}</div>
       <p className={styles.ShowTitle}>{show.title}</p>
       <div className={styles.djs}>{show.DJs.join(", ")}</div>
     </div>
+  }
+  </div>
   );
 }
 

--- a/src/components/DayShow.js
+++ b/src/components/DayShow.js
@@ -11,23 +11,16 @@ export default function DayShow({ show }){
   const genrecolor = colors[show.genres[0].toLowerCase()]
 
   return (
-   <div>
-
-
-    {
-      displayDescription 
-      ? <div className={styles.description} onMouseLeave={() => setDisplayDescription(false)} onMouseEnter={() => setDisplayDescription(true)}>
-        {show.description}
+   <div onMouseLeave={() => setDisplayDescription(false)} onMouseEnter={() => setDisplayDescription(true)}>
+    {displayDescription 
+      ? <div className={styles.description}>
+          {show.description}
         </div> 
-      :
-
-    <div className={styles.details} onMouseEnter={() => setDisplayDescription(true)} onMouseLeave={() => setDisplayDescription(false)} 
-     style={{"backgroundColor": genrecolor}}>
-      <div className={styles.time}>{time}</div>
-      <p className={styles.ShowTitle}>{show.title}</p>
-      <div className={styles.djs}>{show.DJs.join(", ")}</div>
-    </div>
-  }
+      : <div className={styles.details} style={{"backgroundColor": genrecolor}}>
+          <div className={styles.time}>{time}</div>
+          <p className={styles.ShowTitle}>{show.title}</p>
+          <div className={styles.djs}>{show.DJs.join(", ")}</div>
+        </div>}
   </div>
   );
 }

--- a/src/components/WeeklySchedule.js
+++ b/src/components/WeeklySchedule.js
@@ -17,13 +17,19 @@ export default function WeeklySchedule({ shows, setFilter}){
   })
   showsArr.push(firstRow);
 
-  // Add useEffect when writing the onHover function
+  const getHour = (i) => {
+    let hour = i<=12 ? i : i-12;
+    if (hour == 0) {
+      hour = 12
+    }
+    return `${hour}:00${i<=11?" am":" pm"}`;
+  }
 
   for (let i = 0; i < 24; i++){
     showsArr.push([]);
     for (let l = 0; l < 8; l++){
       if (l===0){
-        showsArr[showsArr.length-1].push(<div className={styles.scheduleTime}>{`${i<=12?i:i-12}:00${i<=11?" am":" pm"}`}</div>);
+        showsArr[showsArr.length-1].push(<div className={styles.scheduleTime}>{getHour(i)}</div>);
       }
       else {showsArr[showsArr.length-1].push(undefined)}
     }

--- a/src/components/WeeklySchedule.js
+++ b/src/components/WeeklySchedule.js
@@ -19,7 +19,7 @@ export default function WeeklySchedule({ shows, setFilter}){
 
   const getHour = (i) => {
     let hour = i<=12 ? i : i-12;
-    if (hour == 0) {
+    if (hour === 0) {
       hour = 12
     }
     return `${hour}:00${i<=11?" am":" pm"}`;

--- a/src/lib/component-utils.js
+++ b/src/lib/component-utils.js
@@ -28,7 +28,7 @@ export const compareTwoShows = (a, b) => {
 
 // this function takes a show and return a string of the time in a pretty format, e.g. "9:00 - 10:00 am"
 export const getTimeString = (hour, duration) => {
-  const start = (hour == 0) ? moment(hour, "H") : moment(hour, "Hmm");
+  const start = (hour === 0) ? moment(hour, "H") : moment(hour, "Hmm");
   return `${start.format("h:mm")} - ${start.add(duration, "hour").format("h:mm a")}`;
 }
 

--- a/src/lib/component-utils.js
+++ b/src/lib/component-utils.js
@@ -28,7 +28,7 @@ export const compareTwoShows = (a, b) => {
 
 // this function takes a show and return a string of the time in a pretty format, e.g. "9:00 - 10:00 am"
 export const getTimeString = (hour, duration) => {
-  const start = moment(hour, "Hmm");
+  const start = (hour == 0) ? moment(hour, "H") : moment(hour, "Hmm");
   return `${start.format("h:mm")} - ${start.add(duration, "hour").format("h:mm a")}`;
 }
 

--- a/src/styles/DayShow.module.css
+++ b/src/styles/DayShow.module.css
@@ -1,21 +1,19 @@
 .details {
+  font-size: 15px;
   width: 150px;
   height: 150px;
-  font-size: 15px;
   color: white;
   text-align: center;
-  padding-top: 8px;
-  padding-left: 6px;
-  padding-right: 6px;
+  padding: 8px;
 }
 
 .description {
-  width: 150px;
-  height: 150px;
   font-size: 10px;
-  color: white;
   background-color: black;
   overflow: scroll;
+  width: 150px;
+  height: 150px;
+  color: white;
   text-align: center;
   padding: 8px;
 }

--- a/src/styles/DayShow.module.css
+++ b/src/styles/DayShow.module.css
@@ -1,14 +1,25 @@
-.DayShow {
-  width: 125px;
-  height: 125px;
-  font-size: 10px;
+.details {
+  width: 150px;
+  height: 150px;
+  font-size: 15px;
   color: white;
   text-align: center;
   padding-top: 8px;
   padding-left: 6px;
   padding-right: 6px;
-  
 }
+
+.description {
+  width: 150px;
+  height: 150px;
+  font-size: 10px;
+  color: white;
+  background-color: black;
+  overflow: scroll;
+  text-align: center;
+  padding: 8px;
+}
+
 
 .time, .title, .djs {
   display: inline-block;


### PR DESCRIPTION
We added the hovering feature for the `DayShow` components. Users can now hover over a show and the description is displayed as in the original website. For lengthier descriptions, users can scroll through the description. We also fixed an invalid date bug that showed 12 AM as invalid.

closes #25 